### PR TITLE
Track if a repeated field has been deliberately set

### DIFF
--- a/lib/protobuf/field/base_field.rb
+++ b/lib/protobuf/field/base_field.rb
@@ -176,7 +176,7 @@ module Protobuf
       def define_accessor(simple_field_name, fully_qualified_field_name)
         message_class.class_eval do
           define_method("#{simple_field_name}!") do
-            @values[fully_qualified_field_name]
+            @values[fully_qualified_field_name] if field?(fully_qualified_field_name)
           end
         end
 

--- a/lib/protobuf/message.rb
+++ b/lib/protobuf/message.rb
@@ -94,7 +94,11 @@ module Protobuf
     def field?(name)
       field = self.class.get_field(name, true)
       return false if field.nil?
-      @values.key?(field.fully_qualified_name)
+      if field.repeated?
+        @values.key?(field.fully_qualified_name) && !@values[field.fully_qualified_name].empty?
+      else
+        @values.key?(field.fully_qualified_name)
+      end
     end
     ::Protobuf.deprecator.define_deprecated_methods(self, :has_field? => :field?)
 

--- a/spec/lib/protobuf/message_spec.rb
+++ b/spec/lib/protobuf/message_spec.rb
@@ -476,6 +476,25 @@ RSpec.describe Protobuf::Message do
         message = ::Test::Resource.new(:ext_is_searchable => false)
         expect(message.ext_is_searchable!).to be(false)
       end
+
+      it 'returns nil for an unset repeated field that has only be read' do
+        message = ::Test::Resource.new
+        expect(message.repeated_enum!).to be_nil
+        message.repeated_enum
+        expect(message.repeated_enum!).to be_nil
+      end
+
+      it 'returns value for an unset repeated field has been read and appended to' do
+        message = ::Test::Resource.new
+        message.repeated_enum << 1
+        expect(message.repeated_enum!).to eq([1])
+      end
+
+      it 'returns value for an unset repeated field has been explicitly set' do
+        message = ::Test::Resource.new
+        message.repeated_enum = [1]
+        expect(message.repeated_enum!).to eq([1])
+      end
     end
   end
 
@@ -561,6 +580,31 @@ RSpec.describe Protobuf::Message do
       ext_field = :".test.Searchable.ext_is_searchable"
       message = ::Test::Resource.new(ext_field => false)
       expect(message.field?(100)).to be(true)
+    end
+
+    it 'returns false for repeated field that has been read from' do
+      message = ::Test::Resource.new
+      expect(message.field?(:repeated_enum)).to be(false)
+      message.repeated_enum
+      expect(message.field?(:repeated_enum)).to be(false)
+    end
+
+    it 'returns true for a repeated field that has been read from and appended to' do
+      message = ::Test::Resource.new
+      message.repeated_enum << 1
+      expect(message.field?(:repeated_enum)).to be(true)
+    end
+
+    it 'returns true for a repeated field that has been set with the setter' do
+      message = ::Test::Resource.new
+      message.repeated_enum = [1]
+      expect(message.field?(:repeated_enum)).to be(true)
+    end
+
+    it 'returns false for a repeated field that has been replaced with []' do
+      message = ::Test::Resource.new
+      message.repeated_enum.replace([])
+      expect(message.field?(:repeated_enum)).to be(false)
     end
   end
 


### PR DESCRIPTION
Before, if an unset repeated field was ever read, we would make an empty field array for it. As a consequence, .field? and #{field}! methods would indicate that the field had been set, even though it had only been read from.
This was a weird side effect of reading an unset repeated field and has been corrected.

CC @film42 @nerdrew 

Next piece of https://github.com/ruby-protobuf/protobuf/issues/323
